### PR TITLE
add githook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,38 @@
-## To implement
+default_language_version:
+    python: python3.8
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: check-yaml
+    -   id: trailing-whitespace
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: detect-private-key
+    -   id: no-commit-to-branch
+-   repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+    -   id: bandit
+-   repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.3.0
+    hooks:
+    -   id: pydocstyle
+-   repo: local
+    hooks:
+    -   id: tests
+        name: run test with pipenv
+        language: python
+        entry: pipenv run test
+        types: [python]
+        stages: [commit]
+    -   id: PyLint
+        name: run custom pylint test with pipenv
+        language: python
+        entry: pipenv run lint
+        types: [python]
+        stages: [commit]


### PR DESCRIPTION
Issue number: #6 

---------

## What is the current behavior?
There is no protection for the branch.

## What is the new behavior?
Add protection for the branch. These protection are :

- pass unit test
- pass lint test
- pass test with   https://github.com/pre-commit/pre-commit-hooks
- pass test with Black (formatter)
- pass test with Bandit (security)
- pass test with pydocstyle (PEP8)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
For the project, it does not include a breaking change, but for the developer, this change a lot how then interact with Github. At first must be more difficult to commit, but will help

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Big change for the developer ; must run the commande `pre-commit install` for the hook to take place. use command `pre-commit run` and `pre-commit run --all-files` to detect if the current setup meet the requirement.