### PR TITLE
Features/docker deploy action

### DIFF
--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -29,6 +29,6 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               context: .
-              file: ./dockerfile
+              file: ./Dockerfile
               push: true
               tags: user/app:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -31,4 +31,4 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               push: true
-              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-os-v-${{ github.sha }}
+              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit-$(git rev-parse --short HEAD)

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -31,4 +31,4 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               push: true
-              tags: laurentfrenette/log680:oxygen-cs--latest,laurentfrenette/log680:latest
+              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-os-v-${{ github.sha }}

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -15,6 +15,8 @@ jobs:
     on-success:
       runs-on: ubuntu-latest
       steps:
+        - name: Checkout
+          uses: actions/checkout@v2
         - name: Set up QEMU
           uses: docker/setup-qemu-action@v2
         - name: Set up Docker Buildx
@@ -29,4 +31,4 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               push: true
-              tags: laurentfrenette/log680:latest
+              tags: laurentfrenette/log680:oxygen-cs--latest,laurentfrenette/log680:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -31,4 +31,4 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               push: true
-              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit.${GITHUB_SHA::6}
+              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit-${GITHUB_SHA::6}

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -29,5 +29,6 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               context: .
+              file: ./dockerfile
               push: true
               tags: user/app:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -1,27 +1,31 @@
 
 name: Docker Deploy
 
-on:
-    workflow_run:
-      workflows: [Python package]
-      types: [completed]
+# on:
+#     workflow_run:
+#       workflows: [Python package]
+#       types: [completed]
+        # branches: master
  
+
+on:
+    push:
+  
 jobs:
     on-success:
-        runs-on: ubuntu-latest
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        steps:
-          - name: Set up QEMU
-            uses: docker/setup-qemu-action@v2
-          - name: Set up Docker Buildx
-            uses: docker/setup-buildx-action@v2
-          - name: Login to Docker Hub
-            uses: docker/login-action@v2
-            with:
-                username: ${{ secrets.DOCKERHUB_USERNAME }}
-                password: ${{ secrets.DOCKERHUB_TOKEN }}
-          - name: Build and push
-            uses: docker/build-push-action@v4
-            with:
-                push: true
-                tags: user/app:latest
+      runs-on: ubuntu-latest
+      steps:
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v2
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+        - name: Login to Docker Hub
+          uses: docker/login-action@v2
+          with:
+              username: ${{ secrets.DOCKERHUB_USERNAME }}
+              password: ${{ secrets.DOCKERHUB_TOKEN }}
+        - name: Build and push
+          uses: docker/build-push-action@v4
+          with:
+              push: true
+              tags: user/app:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -29,6 +29,6 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               context: .
-              file: ./Dockerfile
+              file: Dockerfile
               push: true
               tags: user/app:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -31,4 +31,4 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               push: true
-              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit-${GITHUB_SHA::6}
+              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit-$GITHUB_RUN_ID

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -3,7 +3,7 @@ name: Docker Deploy
 
 on:
     workflow_run:
-      workflows: ["Python Package"]
+      workflows: [Python Package]
       types: [completed]
  
 jobs:

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -1,19 +1,16 @@
 
 name: Docker Deploy
 
-# on:
-#     workflow_run:
-#       workflows: [Python package]
-#       types: [completed]
-        # branches: master
- 
-
 on:
-    push:
+    workflow_run:
+      workflows: [Python package]
+      types: [completed]
+      branches: [master, main]
   
 jobs:
     on-success:
       runs-on: ubuntu-latest
+      if: ${{ github.event.workflow_run.conclusion == 'success' }}
       steps:
         - name: Checkout
           uses: actions/checkout@v2

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -3,7 +3,7 @@ name: Docker Deploy
 
 on:
     workflow_run:
-      workflows: [Python Package]
+      workflows: [Python package]
       types: [completed]
  
 jobs:

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -1,0 +1,27 @@
+
+name: Docker Deploy
+
+on:
+    workflow_run:
+      workflows: ["Python Package"]
+      types: [completed]
+ 
+jobs:
+    on-success:
+        runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        steps:
+          - name: Set up QEMU
+            uses: docker/setup-qemu-action@v2
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v2
+          - name: Login to Docker Hub
+            uses: docker/login-action@v2
+            with:
+                username: ${{ secrets.DOCKERHUB_USERNAME }}
+                password: ${{ secrets.DOCKERHUB_TOKEN }}
+          - name: Build and push
+            uses: docker/build-push-action@v4
+            with:
+                push: true
+                tags: user/app:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -31,4 +31,4 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               push: true
-              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit-$(git rev-parse --short HEAD)
+              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit.${GITHUB_SHA::6}

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -24,8 +24,10 @@ jobs:
           with:
               username: ${{ secrets.DOCKERHUB_USERNAME }}
               password: ${{ secrets.DOCKERHUB_TOKEN }}
+        
         - name: Build and push
           uses: docker/build-push-action@v4
           with:
+              context: .
               push: true
               tags: user/app:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -28,7 +28,5 @@ jobs:
         - name: Build and push
           uses: docker/build-push-action@v4
           with:
-              context: .
-              file: Dockerfile
               push: true
-              tags: user/app:latest
+              tags: laurentfrenette/log680:latest

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -31,4 +31,4 @@ jobs:
           uses: docker/build-push-action@v4
           with:
               push: true
-              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit-$GITHUB_RUN_ID
+              tags: laurentfrenette/log680:latest,laurentfrenette/log680:oxygen-cs-commit-${{github.run_id}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,1 +1,38 @@
-## To implement
+default_language_version:
+    python: python3.8
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: check-yaml
+    -   id: trailing-whitespace
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: detect-private-key
+    -   id: no-commit-to-branch
+-   repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+    -   id: bandit
+-   repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.3.0
+    hooks:
+    -   id: pydocstyle
+-   repo: local
+    hooks:
+    -   id: tests
+        name: run test with pipenv
+        language: python
+        entry: pipenv run test
+        types: [python]
+        stages: [commit]
+    -   id: PyLint
+        name: run custom pylint test with pipenv
+        language: python
+        entry: pipenv run lint
+        types: [python]
+        stages: [commit]


### PR DESCRIPTION
Issue number: #14 

---------

## What is the current behavior?
Currently, we have to manually deploy image of Docker in the Docker Hub. 

## What is the new behavior?
If the branch succeded all the test and is merge (with a PR) into `main`, an other action will be executed. It will create the Docker image and push it in ours Docker Hub with these 2 tags : 

- latest
- oxygen-cs-commit-${{ action run ID }}

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

close #14